### PR TITLE
Fix bug in boundary_step() in circle tests

### DIFF
--- a/tests/test_cpt.py
+++ b/tests/test_cpt.py
@@ -137,16 +137,19 @@ def test_density_preserving(mesh, ref):
 def test_circle():
     def boundary_step(x):
         x0 = [0.0, 0.0]
-        r = 1.0
+        R = 1.0
         # simply project onto the circle
         y = (x.T - x0).T
         r = np.sqrt(np.einsum("ij,ij->j", y, y))
-        return ((y / r * r).T + x0).T
+        return ((y / r * R).T + x0).T
 
     X, cells = meshes.circle_random2(150, 1.0)
     X, cells = optimesh.optimize_points_cells(
         X, cells, "cpt (fixed-point)", 1.0e-3, 100, boundary_step=boundary_step
     )
+
+    mesh = MeshTri(X, cells)
+    mesh.show()
 
 
 if __name__ == "__main__":

--- a/tests/test_cvt.py
+++ b/tests/test_cvt.py
@@ -77,7 +77,7 @@ def test_cvt_qnb(mesh, ref):
     assert_norm_equality(m.points, ref, 1.0e-9)
 
 
-def test_cvt_qnb_boundary(n=50):
+def test_cvt_qnb_boundary(n=10):
     X, cells = create_random_circle(n=n, radius=1.0)
 
     def boundary_step(x):

--- a/tests/test_cvt.py
+++ b/tests/test_cvt.py
@@ -77,16 +77,16 @@ def test_cvt_qnb(mesh, ref):
     assert_norm_equality(m.points, ref, 1.0e-9)
 
 
-def test_cvt_qnb_boundary(n=10):
+def test_cvt_qnb_boundary(n=50):
     X, cells = create_random_circle(n=n, radius=1.0)
 
     def boundary_step(x):
         x0 = [0.0, 0.0]
-        r = 1.0
+        R = 1.0
         # simply project onto the circle
         y = (x.T - x0).T
         r = np.sqrt(np.einsum("ij,ij->j", y, y))
-        return ((y / r * r).T + x0).T
+        return ((y / r * R).T + x0).T
 
     mesh = meshplex.MeshTri(X, cells)
     optimesh.optimize(mesh, "Lloyd", 1.0e-2, 100, boundary_step=boundary_step)

--- a/tests/test_odt.py
+++ b/tests/test_odt.py
@@ -2,6 +2,7 @@ import copy
 
 import numpy as np
 import pytest
+from meshplex import MeshTri
 
 import optimesh
 
@@ -51,11 +52,11 @@ def test_nonlinear_optimization(mesh, ref):
 def test_circle():
     def boundary_step(x):
         x0 = [0.0, 0.0]
-        r = 1.0
+        R = 1.0
         # simply project onto the circle
         y = (x.T - x0).T
         r = np.sqrt(np.einsum("ij,ij->j", y, y))
-        return ((y / r * r).T + x0).T
+        return ((y / r * R).T + x0).T
 
     # ODT can't handle the random circle; some cells too flat near the boundary lead to
     # a breakdown.
@@ -64,6 +65,9 @@ def test_circle():
     X, cells = optimesh.optimize_points_cells(
         X, cells, "ODT (fixed-point)", 1.0e-3, 100, boundary_step=boundary_step
     )
+
+    mesh = MeshTri(X, cells)
+    mesh.show()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
...weird that this hasn't been caught by flake8 before.

Verify the fix by running
```
pytest test_cpt.py -k test_circle
pytest test_cvt.py -k test_cvt_qnb_boundary
pytest test_odt.py -k test_circle
```
and looking at the plots.